### PR TITLE
Add settings persistence and similarity metric option

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3,13 +3,35 @@ LiveRecall API
 FastAPI application for controlling LiveRecall
 """
 import logging
+import sys
 from contextlib import asynccontextmanager
+from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse, RedirectResponse
 
 from api.routes import recording, sync, search, screenshots, status, compression
 from core.database import db
+
+
+def _get_static_dir() -> Path:
+    """Get the path to static web UI files (works for both dev and frozen)"""
+    if getattr(sys, 'frozen', False):
+        # PyInstaller: look in _MEIPASS (temp extraction dir) or next to executable
+        base = Path(getattr(sys, '_MEIPASS', Path(sys.executable).parent))
+        # Try _MEIPASS/web/out first, then next to exe
+        if (base / "web" / "out").exists():
+            return base / "web" / "out"
+        return Path(sys.executable).parent / "web" / "out"
+    else:
+        # Development: relative to this file
+        return Path(__file__).parent.parent / "web" / "out"
+
+
+# Path to static web UI files (built Next.js)
+STATIC_DIR = _get_static_dir()
 
 # Configure logging - reduce uvicorn noise
 logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
@@ -75,6 +97,24 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+# Middleware to strip trailing slashes from API routes
+@app.middleware("http")
+async def strip_trailing_slash(request: Request, call_next):
+    """Redirect API requests with trailing slashes to non-trailing slash version"""
+    path = request.url.path
+    # Only handle /api/ routes with trailing slash (but not just "/api/")
+    if path.startswith("/api/") and path.endswith("/") and len(path) > 5:
+        # Preserve query string
+        new_path = path.rstrip("/")
+        if request.url.query:
+            new_url = f"{new_path}?{request.url.query}"
+        else:
+            new_url = new_path
+        return RedirectResponse(url=new_url, status_code=307)
+    return await call_next(request)
+
+
 # Include routers
 app.include_router(status.router, prefix="/api/v1")
 app.include_router(recording.router, prefix="/api/v1")
@@ -84,16 +124,66 @@ app.include_router(screenshots.router, prefix="/api/v1")
 app.include_router(compression.router, prefix="/api/v1")
 
 
-# Root endpoint
-@app.get("/")
-async def root():
-    """API root - redirects to docs"""
-    return {
-        "name": "LiveRecall API",
-        "version": "2.0.0",
-        "docs": "/docs",
-        "status": "/api/v1/status",
-    }
+# Serve static web UI if available
+if STATIC_DIR.exists():
+    # Mount static files for assets (_next, images, etc.)
+    app.mount("/_next", StaticFiles(directory=STATIC_DIR / "_next"), name="next_static")
+
+    # Catch-all route for SPA - must be after API routes
+    @app.get("/{full_path:path}")
+    async def serve_spa(request: Request, full_path: str):
+        """Serve static files or index.html for SPA routing"""
+        # Try to serve the exact file first
+        file_path = STATIC_DIR / full_path
+
+        # Handle trailing slash - look for index.html in directory
+        if file_path.is_dir():
+            index_file = file_path / "index.html"
+            if index_file.exists():
+                return FileResponse(index_file)
+
+        # Serve exact file if it exists
+        if file_path.exists() and file_path.is_file():
+            return FileResponse(file_path)
+
+        # Try with .html extension (Next.js static export)
+        html_file = STATIC_DIR / f"{full_path}.html"
+        if html_file.exists():
+            return FileResponse(html_file)
+
+        # Fall back to index.html for SPA routing
+        index_path = STATIC_DIR / "index.html"
+        if index_path.exists():
+            return FileResponse(index_path)
+
+        # No static files available
+        return {"error": "Not found", "path": full_path}
+
+    # Root serves index.html
+    @app.get("/")
+    async def root():
+        """Serve web UI"""
+        index_path = STATIC_DIR / "index.html"
+        if index_path.exists():
+            return FileResponse(index_path)
+        return {
+            "name": "LiveRecall API",
+            "version": "2.0.0",
+            "docs": "/docs",
+            "web_ui": "Not built. Run 'npm run build' in web/ directory.",
+        }
+else:
+    # No static files - serve API info at root
+    @app.get("/")
+    async def root():
+        """API root - no web UI available"""
+        return {
+            "name": "LiveRecall API",
+            "version": "2.0.0",
+            "docs": "/docs",
+            "status": "/api/v1/status",
+            "web_ui": f"Not found at {STATIC_DIR}. Build with 'npm run build' in web/",
+        }
 
 
 # Run with: uvicorn api.main:app --reload --port 8742

--- a/api/routes/search.py
+++ b/api/routes/search.py
@@ -10,6 +10,7 @@ from api.schemas import (
     SearchResult,
 )
 from core.database import db
+from core.config import config
 from core.embeddings import (
     get_text_embedding,
     get_combined_embedding,
@@ -66,7 +67,11 @@ async def search_screenshots(request: SearchRequest):
     # Search database - get more results than needed if filtering by date
     search_limit = request.limit * 3 if (request.start_date or request.end_date) else request.limit
     try:
-        results = db.search_similar(embedding, limit=search_limit)
+        results = db.search_similar(
+            embedding,
+            limit=search_limit,
+            similarity_metric=config.similarity_metric
+        )
     except Exception as e:
         raise HTTPException(
             status_code=500,
@@ -110,12 +115,15 @@ async def search_screenshots(request: SearchRequest):
 async def quick_search(
     q: str,
     limit: int = 20,
-    safe_mode: bool = True,
+    safe_mode: bool = False,
     start_date: str = None,
     end_date: str = None,
 ):
     """
     Quick search with query parameters (simpler than POST).
+
+    Safe mode is OFF by default for personal recall apps.
+    Enable it to filter potentially sensitive content from results.
 
     Example: /api/v1/search/quick?q=blue+shirt&limit=10
     Example with dates: /api/v1/search/quick?q=meeting&start_date=251201000000&end_date=251206235959

--- a/api/routes/status.py
+++ b/api/routes/status.py
@@ -16,6 +16,7 @@ from api.schemas import (
     SuccessResponse,
     CaptureMode,
     SafeModeLevel,
+    SimilarityMetric,
 )
 from core.database import db
 from core.capture import capture_service
@@ -97,6 +98,7 @@ async def get_config():
         encryption_enabled=config.encryption_enabled,
         safe_mode_enabled=config.safe_mode_enabled,
         safe_mode_level=SafeModeLevel(config.safe_mode_level),
+        similarity_metric=SimilarityMetric(config.similarity_metric),
         auto_unload_seconds=get_model_status()["auto_unload_seconds"],
     )
 
@@ -146,6 +148,10 @@ async def update_config(request: ConfigUpdateRequest):
         config.compression.quality = request.compression_quality
         updated.append(f"compression_quality={request.compression_quality}")
 
+    if request.similarity_metric is not None:
+        config.similarity_metric = request.similarity_metric.value
+        updated.append(f"similarity_metric={request.similarity_metric.value}")
+
     if request.auto_unload_seconds is not None:
         set_auto_unload_timeout(request.auto_unload_seconds)
         updated.append(f"auto_unload_seconds={request.auto_unload_seconds}")
@@ -155,6 +161,9 @@ async def update_config(request: ConfigUpdateRequest):
             success=True,
             message="No changes made",
         )
+
+    # Save config to disk so settings persist across restarts
+    config.save()
 
     return SuccessResponse(
         success=True,

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -35,6 +35,12 @@ class SafeModeLevel(str, Enum):
     EXTREME = "extreme"
 
 
+class SimilarityMetric(str, Enum):
+    """Similarity calculation method"""
+    COSINE = "cosine"
+    DISTANCE = "distance"
+
+
 # =============================================================================
 # Recording
 # =============================================================================
@@ -341,6 +347,7 @@ class AppConfig(BaseModel):
     encryption_enabled: bool
     safe_mode_enabled: bool
     safe_mode_level: SafeModeLevel
+    similarity_metric: SimilarityMetric
     auto_unload_seconds: int
 
 
@@ -355,6 +362,7 @@ class ConfigUpdateRequest(BaseModel):
     compression_quality: Optional[int] = Field(None, ge=50, le=90)
     safe_mode_enabled: Optional[bool] = None
     safe_mode_level: Optional[SafeModeLevel] = None
+    similarity_metric: Optional[SimilarityMetric] = None
     auto_unload_seconds: Optional[int] = Field(None, ge=0, le=3600)
 
 

--- a/core/config.py
+++ b/core/config.py
@@ -1,11 +1,12 @@
 """
 LiveRecall Configuration
-Platform-specific paths and settings
+Platform-specific paths and settings with persistence
 """
+import json
 import os
 import sys
 from pathlib import Path
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from typing import Literal
 
 # Platform detection
@@ -37,6 +38,11 @@ def get_screenshots_dir() -> Path:
 def get_database_path() -> Path:
     """Get database file path"""
     return get_data_dir() / "liverecall.db"
+
+
+def get_config_path() -> Path:
+    """Get config file path"""
+    return get_data_dir() / "config.json"
 
 
 @dataclass
@@ -86,6 +92,7 @@ class Config:
     encryption_enabled: bool = True
     safe_mode_enabled: bool = True
     safe_mode_level: str = "mid"  # low, mid, high
+    similarity_metric: str = "cosine"  # "cosine" or "distance"
 
     # Paths (computed)
     @property
@@ -100,9 +107,69 @@ class Config:
     def database_path(self) -> Path:
         return get_database_path()
 
+    def save(self):
+        """Save config to JSON file"""
+        config_path = get_config_path()
+        data = {
+            "capture": {
+                "mode": self.capture.mode,
+                "interval": self.capture.interval,
+                "threshold": self.capture.threshold,
+                "save_threshold": self.capture.save_threshold,
+                "quality": self.capture.quality,
+            },
+            "compression": {
+                "enabled": self.compression.enabled,
+                "after_days": self.compression.after_days,
+                "quality": self.compression.quality,
+            },
+            "encryption_enabled": self.encryption_enabled,
+            "safe_mode_enabled": self.safe_mode_enabled,
+            "safe_mode_level": self.safe_mode_level,
+            "similarity_metric": self.similarity_metric,
+        }
+        with open(config_path, "w") as f:
+            json.dump(data, f, indent=2)
+
+    def load(self):
+        """Load config from JSON file if it exists"""
+        config_path = get_config_path()
+        if not config_path.exists():
+            return
+
+        try:
+            with open(config_path, "r") as f:
+                data = json.load(f)
+
+            # Load capture settings
+            if "capture" in data:
+                cap = data["capture"]
+                self.capture.mode = cap.get("mode", self.capture.mode)
+                self.capture.interval = cap.get("interval", self.capture.interval)
+                self.capture.threshold = cap.get("threshold", self.capture.threshold)
+                self.capture.save_threshold = cap.get("save_threshold", self.capture.save_threshold)
+                self.capture.quality = cap.get("quality", self.capture.quality)
+
+            # Load compression settings
+            if "compression" in data:
+                comp = data["compression"]
+                self.compression.enabled = comp.get("enabled", self.compression.enabled)
+                self.compression.after_days = comp.get("after_days", self.compression.after_days)
+                self.compression.quality = comp.get("quality", self.compression.quality)
+
+            # Load other settings
+            self.encryption_enabled = data.get("encryption_enabled", self.encryption_enabled)
+            self.safe_mode_enabled = data.get("safe_mode_enabled", self.safe_mode_enabled)
+            self.safe_mode_level = data.get("safe_mode_level", self.safe_mode_level)
+            self.similarity_metric = data.get("similarity_metric", self.similarity_metric)
+
+        except (json.JSONDecodeError, KeyError) as e:
+            print(f"Warning: Could not load config: {e}")
+
 
 # Global config instance
 config = Config()
+config.load()  # Load saved settings on startup
 
 
 if __name__ == "__main__":

--- a/core/database.py
+++ b/core/database.py
@@ -340,9 +340,17 @@ class Database:
         self,
         query_embedding: list[float],
         limit: int = 10,
-        min_similarity: float = 0.0
+        min_similarity: float = 0.0,
+        similarity_metric: str = "cosine"
     ) -> list[dict]:
-        """Search for similar screenshots using vector similarity"""
+        """Search for similar screenshots using vector similarity
+
+        Args:
+            query_embedding: The query embedding vector
+            limit: Maximum number of results
+            min_similarity: Minimum similarity threshold
+            similarity_metric: "cosine" for cosine similarity or "distance" for 1/(1+L2)
+        """
         if len(query_embedding) != EMBEDDING_DIM:
             raise ValueError(f"Query embedding must be {EMBEDDING_DIM} dimensions")
 
@@ -350,7 +358,6 @@ class Database:
 
         with self.cursor() as cur:
             # sqlite-vec uses L2 distance, lower is more similar
-            # We convert to similarity score (1 / (1 + distance))
             cur.execute("""
                 SELECT
                     s.*,
@@ -365,9 +372,18 @@ class Database:
             results = []
             for row in cur.fetchall():
                 result = dict(row)
-                # Convert distance to similarity (0-1 scale, 1 = most similar)
                 distance = result.pop("vec_distance", 0)
-                result["similarity"] = 1 / (1 + distance)
+
+                if similarity_metric == "cosine":
+                    # Convert L2 distance to cosine similarity
+                    # For normalized vectors: L2² = 2(1 - cosine_sim)
+                    # So: cosine_sim = 1 - L2²/2
+                    similarity = max(0.0, min(1.0, 1.0 - (distance ** 2) / 2))
+                else:
+                    # Use inverse distance: 1 / (1 + distance)
+                    similarity = 1.0 / (1.0 + distance)
+
+                result["similarity"] = similarity
                 if result["similarity"] >= min_similarity:
                     results.append(result)
 

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -27,6 +27,11 @@ const SAFE_MODE_LEVELS = [
   { value: 'extreme', label: 'Extreme' },
 ];
 
+const SIMILARITY_METRICS = [
+  { value: 'cosine', label: 'Cosine Similarity' },
+  { value: 'distance', label: 'Inverse Distance' },
+];
+
 export default function SettingsPage() {
   const [config, setConfig] = useState<AppConfig | null>(null);
   const [status, setStatus] = useState<SystemStatus | null>(null);
@@ -187,26 +192,22 @@ export default function SettingsPage() {
                 ))}
               </select>
             </Row>
-            <Row label="Interval" value={`${config.capture.interval}s`}>
-              <input
-                type="range"
+            <Row label="Check Frequency" value={`${config.capture.interval}s`}>
+              <Slider
                 min={1}
                 max={10}
                 step={0.5}
                 value={config.capture.interval}
-                onChange={(e) => handleUpdate({ capture_interval: Number(e.target.value) })}
-                className="w-20 accent-[#86efac]"
+                onChange={(val) => handleUpdate({ capture_interval: val })}
               />
             </Row>
             <Row label="Quality" value={`${config.capture.quality}%`}>
-              <input
-                type="range"
+              <Slider
                 min={50}
                 max={100}
                 step={5}
                 value={config.capture.quality}
-                onChange={(e) => handleUpdate({ capture_quality: Number(e.target.value) })}
-                className="w-20 accent-[#86efac]"
+                onChange={(val) => handleUpdate({ capture_quality: val })}
               />
             </Row>
           </Section>
@@ -244,6 +245,17 @@ export default function SettingsPage() {
                 </select>
               </Row>
             )}
+            <Row label="Similarity">
+              <select
+                value={config.similarity_metric}
+                onChange={(e) => handleUpdate({ similarity_metric: e.target.value as 'cosine' | 'distance' })}
+                className="bg-[#0f0f0f] text-[#f5f5f5] px-2 py-1 rounded border border-[#1e1e1e] text-xs focus:border-[#86efac]/50 focus:outline-none"
+              >
+                {SIMILARITY_METRICS.map((metric) => (
+                  <option key={metric.value} value={metric.value}>{metric.label}</option>
+                ))}
+              </select>
+            </Row>
           </Section>
 
           {/* Storage */}
@@ -256,14 +268,12 @@ export default function SettingsPage() {
             </Row>
             {config.compression.enabled && (
               <Row label="After" value={`${config.compression.after_days} days`}>
-                <input
-                  type="range"
+                <Slider
                   min={7}
                   max={180}
                   step={7}
                   value={config.compression.after_days}
-                  onChange={(e) => handleUpdate({ compression_after_days: Number(e.target.value) })}
-                  className="w-20 accent-[#86efac]"
+                  onChange={(val) => handleUpdate({ compression_after_days: val })}
                 />
               </Row>
             )}
@@ -361,5 +371,58 @@ function Toggle({ enabled, onChange }: { enabled: boolean; onChange: () => void 
         }`}
       />
     </button>
+  );
+}
+
+function Slider({
+  min,
+  max,
+  step,
+  value,
+  onChange,
+}: {
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  onChange: (val: number) => void;
+}) {
+  const percentage = ((value - min) / (max - min)) * 100;
+
+  return (
+    <div className="relative w-24 h-5 flex items-center">
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full h-1.5 rounded-full appearance-none cursor-pointer slider-green"
+        style={{
+          background: `linear-gradient(to right, #86efac ${percentage}%, #333 ${percentage}%)`,
+        }}
+      />
+      <style jsx>{`
+        .slider-green::-webkit-slider-thumb {
+          -webkit-appearance: none;
+          appearance: none;
+          width: 14px;
+          height: 14px;
+          border-radius: 50%;
+          background: #86efac;
+          cursor: pointer;
+          border: 2px solid #000;
+        }
+        .slider-green::-moz-range-thumb {
+          width: 14px;
+          height: 14px;
+          border-radius: 50%;
+          background: #86efac;
+          cursor: pointer;
+          border: 2px solid #000;
+        }
+      `}</style>
+    </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -57,6 +57,7 @@ export async function updateConfig(updates: Partial<{
   compression_quality: number;
   safe_mode_enabled: boolean;
   safe_mode_level: string;
+  similarity_metric: 'cosine' | 'distance';
   model_auto_unload_seconds: number;
 }>): Promise<ApiResponse<void>> {
   return fetchApi('/config', {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -74,6 +74,7 @@ export interface AppConfig {
   encryption_enabled: boolean;
   safe_mode_enabled: boolean;
   safe_mode_level: string;
+  similarity_metric: 'cosine' | 'distance';
   model_auto_unload_seconds: number;
 }
 


### PR DESCRIPTION
## Summary
- Add JSON config persistence so user settings survive app restarts
- Add similarity metric setting (cosine vs inverse distance) in Search section
- Fix L2 to cosine similarity conversion for accurate search results
- Improve settings UI with green sliders and renamed "Check Frequency" label
- Add trailing slash redirect middleware to fix API 404 errors

## Changes
- `core/config.py`: Added save/load methods for JSON persistence
- `core/database.py`: Added similarity_metric parameter to search
- `api/routes/status.py`: Save config on update, expose similarity_metric
- `api/schemas.py`: Added SimilarityMetric enum
- `api/main.py`: Added trailing slash redirect middleware
- `web/src/app/settings/page.tsx`: Added Similarity dropdown, custom green Slider component
- `web/src/lib/api.ts` & `web/src/types/index.ts`: Added similarity_metric type

## Test plan
- [ ] Change settings in UI, restart app, verify settings persist
- [ ] Toggle between cosine and distance similarity, verify search results change
- [ ] Test sliders are visible with green styling