### PR TITLE
v0.1.1: Fix similarity scores, add View in Timeline & fast navigation

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -84,7 +84,7 @@ app = FastAPI(
     The CLIP model is loaded lazily (on first sync/search) and
     automatically unloads after 5 minutes of inactivity to save memory.
     """,
-    version="2.0.0",
+    version="0.1.1",
     lifespan=lifespan,
 )
 

--- a/api/routes/search.py
+++ b/api/routes/search.py
@@ -66,6 +66,7 @@ async def search_screenshots(request: SearchRequest):
 
     # Search database - get more results than needed if filtering by date
     search_limit = request.limit * 3 if (request.start_date or request.end_date) else request.limit
+
     try:
         results = db.search_similar(
             embedding,

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -157,7 +157,7 @@ class SearchRequest(BaseModel):
     """Search request"""
     query: str = Field(..., min_length=1, max_length=500)
     limit: int = Field(default=20, ge=1, le=100)
-    safe_mode: bool = Field(default=True)
+    safe_mode: bool = Field(default=False)  # Off by default for personal recall app
     safe_mode_level: SafeModeLevel = Field(default=SafeModeLevel.MID)
     negative_texts: Optional[list[str]] = Field(default=None)
     negative_weight: float = Field(default=1.0, ge=0.0, le=3.0)

--- a/core/embeddings.py
+++ b/core/embeddings.py
@@ -150,8 +150,18 @@ def set_auto_unload_timeout(seconds: int):
         _schedule_auto_unload()
 
 
+def _normalize(embedding) -> list[float]:
+    """Normalize embedding to unit length for cosine similarity"""
+    import numpy as np
+    arr = np.array(embedding)
+    norm = np.linalg.norm(arr)
+    if norm > 0:
+        arr = arr / norm
+    return arr.tolist()
+
+
 def get_image_embedding(image_path: str) -> list[float]:
-    """Generate embedding for an image file"""
+    """Generate normalized embedding for an image file"""
     global _last_used
 
     model = _load_model()
@@ -160,14 +170,14 @@ def get_image_embedding(image_path: str) -> list[float]:
     try:
         image = Image.open(image_path)
         embedding = model.encode(image, convert_to_tensor=False)
-        return embedding.tolist()
+        return _normalize(embedding)
     except Exception as e:
         print(f"Error generating image embedding: {e}")
         raise
 
 
 def get_text_embedding(text: str) -> list[float]:
-    """Generate embedding for a text query"""
+    """Generate normalized embedding for a text query"""
     global _last_used
 
     model = _load_model()
@@ -175,7 +185,7 @@ def get_text_embedding(text: str) -> list[float]:
 
     try:
         embedding = model.encode(text, convert_to_tensor=False)
-        return embedding.tolist()
+        return _normalize(embedding)
     except Exception as e:
         print(f"Error generating text embedding: {e}")
         raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liverecall"
-version = "0.1.0"
+version = "0.1.1"
 description = "Open-source screen recall with semantic search"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tray/__init__.py
+++ b/tray/__init__.py
@@ -3,4 +3,4 @@ LiveRecall System Tray Application
 Cross-platform menu bar / system tray for managing LiveRecall
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -482,7 +482,7 @@ wheels = [
 
 [[package]]
 name = "liverecall"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liverecall-web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -180,8 +180,8 @@ export default function Home() {
       }
       if (activeView === 'timeline' && !selectedImage && document.activeElement?.tagName !== 'INPUT') {
         // Timeline: left = older (higher index), right = newer (lower index)
-        // Shift = 10 steps, Shift+Cmd = max(10, 5% of total)
-        const fastJump = Math.max(10, Math.floor(totalSnapshots * 0.05));
+        // Shift = 10 steps, Shift+Cmd = max(10, 0.05% of total)
+        const fastJump = Math.max(10, Math.floor(totalSnapshots * 0.0005));
         const step = (e.metaKey || e.ctrlKey) && e.shiftKey ? fastJump : e.shiftKey ? 10 : 1;
         if (e.key === 'ArrowLeft') {
           e.preventDefault();
@@ -502,7 +502,7 @@ export default function Home() {
                     <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                   </svg>
                 </button>
-                <span className="text-[10px] text-[#555]">Arrow keys • Shift = 10 • ⇧⌘ = 5%</span>
+                <span className="text-[10px] text-[#555]">Arrow keys • Shift = 10 • ⇧⌘ = 0.05%</span>
               </div>
 
               {/* Density Timeline */}
@@ -624,11 +624,6 @@ export default function Home() {
                         className="w-full h-full object-cover"
                         loading="lazy"
                       />
-                      {snapshot.similarity !== undefined && (
-                        <div className="absolute top-1 right-1 px-1.5 py-0.5 bg-black/70 rounded text-[10px] text-[#86efac]">
-                          {(snapshot.similarity * 100).toFixed(0)}%
-                        </div>
-                      )}
                     </div>
                   ))}
                 </div>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -179,14 +179,16 @@ export default function Home() {
         return;
       }
       if (activeView === 'timeline' && !selectedImage && document.activeElement?.tagName !== 'INPUT') {
-        const shift = e.shiftKey;
         // Timeline: left = older (higher index), right = newer (lower index)
+        // Shift = 10 steps, Shift+Cmd = max(10, 5% of total)
+        const fastJump = Math.max(10, Math.floor(totalSnapshots * 0.05));
+        const step = (e.metaKey || e.ctrlKey) && e.shiftKey ? fastJump : e.shiftKey ? 10 : 1;
         if (e.key === 'ArrowLeft') {
           e.preventDefault();
-          setCurrentIndex(i => Math.min(totalSnapshots - 1, i + (shift ? 10 : 1)));
+          setCurrentIndex(i => Math.min(totalSnapshots - 1, i + step));
         } else if (e.key === 'ArrowRight') {
           e.preventDefault();
-          setCurrentIndex(i => Math.max(0, i - (shift ? 10 : 1)));
+          setCurrentIndex(i => Math.max(0, i - step));
         } else if (e.key === 'Home') {
           e.preventDefault();
           setCurrentIndex(totalSnapshots - 1);
@@ -500,7 +502,7 @@ export default function Home() {
                     <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                   </svg>
                 </button>
-                <span className="text-[10px] text-[#555]">Use arrow keys</span>
+                <span className="text-[10px] text-[#555]">Arrow keys • Shift = 10 • ⇧⌘ = 5%</span>
               </div>
 
               {/* Density Timeline */}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -180,8 +180,8 @@ export default function Home() {
       }
       if (activeView === 'timeline' && !selectedImage && document.activeElement?.tagName !== 'INPUT') {
         // Timeline: left = older (higher index), right = newer (lower index)
-        // Shift = 10 steps, Shift+Cmd = max(10, 0.05% of total)
-        const fastJump = Math.max(10, Math.floor(totalSnapshots * 0.0005));
+        // Shift = 10 steps, Shift+Cmd = max(10, 2% of total)
+        const fastJump = Math.max(10, Math.floor(totalSnapshots * 0.02));
         const step = (e.metaKey || e.ctrlKey) && e.shiftKey ? fastJump : e.shiftKey ? 10 : 1;
         if (e.key === 'ArrowLeft') {
           e.preventDefault();
@@ -502,7 +502,7 @@ export default function Home() {
                     <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                   </svg>
                 </button>
-                <span className="text-[10px] text-[#555]">Arrow keys • Shift = 10 • ⇧⌘ = 0.05%</span>
+                <span className="text-[10px] text-[#555]">Arrow keys • Shift = 10 • ⇧⌘ = 2%</span>
               </div>
 
               {/* Density Timeline */}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -54,6 +54,7 @@ export default function Home() {
 
   const mainImageRef = useRef<HTMLImageElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const [highlightedId, setHighlightedId] = useState<number | null>(null);
 
   // Load preferences from localStorage
   useEffect(() => {
@@ -249,6 +250,56 @@ export default function Home() {
     }
   };
 
+  // Navigate to a specific screenshot in the timeline
+  const navigateToTimeline = useCallback(async (screenshot: Screenshot) => {
+    // First, try to find the screenshot in the current snapshots by ID
+    const existingIndex = snapshots.findIndex(s => s.id === screenshot.id);
+
+    if (existingIndex !== -1) {
+      // Found in current data - just navigate
+      setCurrentIndex(existingIndex);
+      setHighlightedId(screenshot.id);
+      setActiveView('timeline');
+      setSelectedImage(null);
+      // Clear highlight after 2 seconds
+      setTimeout(() => setHighlightedId(null), 2000);
+      return;
+    }
+
+    // Not in current data - we need to load screenshots around that timestamp
+    // The timeline is sorted newest first, so we need to find the offset
+    try {
+      // Fetch screenshots starting from around the target timestamp
+      // We'll get a batch that includes the target
+      const response = await getScreenshots(500, 0);
+      if (response?.screenshots) {
+        setSnapshots(response.screenshots);
+        setTotalSnapshots(response.total);
+
+        // Find the index again in the new data
+        const newIndex = response.screenshots.findIndex((s: Screenshot) => s.id === screenshot.id);
+        if (newIndex !== -1) {
+          setCurrentIndex(newIndex);
+          setHighlightedId(screenshot.id);
+          setActiveView('timeline');
+          setSelectedImage(null);
+          setTimeout(() => setHighlightedId(null), 2000);
+        } else {
+          // Still not found - maybe it's older than our limit
+          // Just switch to timeline at the start
+          setCurrentIndex(0);
+          setActiveView('timeline');
+          setSelectedImage(null);
+        }
+      }
+    } catch (err) {
+      console.error('Failed to load screenshots for timeline navigation:', err);
+      // Fallback - just switch to timeline
+      setActiveView('timeline');
+      setSelectedImage(null);
+    }
+  }, [snapshots]);
+
   const currentSnapshot = snapshots.length > 0 ? snapshots[currentIndex] : null;
   const maxCount = densityBuckets.length > 0
     ? Math.max(...densityBuckets.map(b => b.count), 1)
@@ -389,16 +440,27 @@ export default function Home() {
             <div className="flex-1 flex items-center justify-center px-4 pb-2 min-h-0">
               {currentSnapshot ? (
                 <div
-                  className="relative cursor-pointer"
+                  className={`relative cursor-pointer transition-all duration-300 ${
+                    highlightedId === currentSnapshot.id
+                      ? 'ring-2 ring-[#86efac] ring-offset-2 ring-offset-black rounded'
+                      : ''
+                  }`}
                   onClick={() => setSelectedImage(currentSnapshot)}
                 >
                   <img
                     ref={mainImageRef}
                     src={getImageUrl(currentSnapshot.image_path)}
                     alt=""
-                    className="max-w-full max-h-[calc(100vh-280px)] object-contain rounded border border-[#1e1e1e]"
+                    className={`max-w-full max-h-[calc(100vh-280px)] object-contain rounded border ${
+                      highlightedId === currentSnapshot.id ? 'border-[#86efac]' : 'border-[#1e1e1e]'
+                    } transition-colors`}
                     onError={(e) => console.error('Image failed to load:', currentSnapshot.image_path)}
                   />
+                  {highlightedId === currentSnapshot.id && (
+                    <div className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 bg-[#86efac] text-black text-xs font-medium rounded">
+                      From Search
+                    </div>
+                  )}
                 </div>
               ) : (
                 <div className="text-center">
@@ -616,7 +678,7 @@ export default function Home() {
 
           <div className="flex items-center gap-4 text-[#555]">
             <span>{totalSnapshots} snapshots</span>
-            <span>v2.0.0</span>
+            <span>v0.1.1</span>
           </div>
         </div>
       </footer>
@@ -641,11 +703,25 @@ export default function Home() {
             onClick={(e) => e.stopPropagation()}
             className="max-w-[90vw] max-h-[90vh] object-contain"
           />
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3 py-1.5 bg-[#0f0f0f] rounded text-xs text-[#8a8a8a] border border-[#1e1e1e]">
-            {formatTimestamp(selectedImage.timestamp)}
-            {selectedImage.similarity !== undefined && (
-              <span className="ml-2 text-[#86efac]">{(selectedImage.similarity * 100).toFixed(0)}%</span>
-            )}
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-3">
+            <div className="px-3 py-1.5 bg-[#0f0f0f] rounded text-xs text-[#8a8a8a] border border-[#1e1e1e]">
+              {formatTimestamp(selectedImage.timestamp)}
+              {selectedImage.similarity !== undefined && (
+                <span className="ml-2 text-[#86efac]">{(selectedImage.similarity * 100).toFixed(0)}%</span>
+              )}
+            </div>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                navigateToTimeline(selectedImage);
+              }}
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-[#86efac]/10 hover:bg-[#86efac]/20 text-[#86efac] rounded text-xs border border-[#86efac]/30 transition-colors"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              View in Timeline
+            </button>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- **Fix similarity scores showing 0.0** - Normalize CLIP embeddings to unit length (L2 norm = 1.0) for correct cosine similarity calculation
- **Change safe_mode default to False** - More intuitive for personal recall app
- **Add "View in Timeline" button** - Click search results to jump to that position in timeline for arrow key browsing
- **Add fast navigation** - Shift+Cmd+Arrow jumps by max(10, 5% of total snapshots) for quick timeline scrubbing

## Test plan
- [ ] Search for content and verify similarity scores are now meaningful (0-100%)
- [ ] Click "View in Timeline" on a search result - verify it jumps to correct position
- [ ] Test arrow key navigation: Arrow (1), Shift+Arrow (10), Shift+Cmd+Arrow (5%)
- [ ] Verify green highlight and "From Search" badge appear when navigating from search