### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -84,7 +84,7 @@ app = FastAPI(
     The CLIP model is loaded lazily (on first sync/search) and
     automatically unloads after 5 minutes of inactivity to save memory.
     """,
-    version="0.1.1",
+    version="0.1.2",
     lifespan=lifespan,
 )
 

--- a/core/updater.py
+++ b/core/updater.py
@@ -8,7 +8,7 @@ from typing import Optional, Callable
 import httpx
 
 # Current version
-VERSION = "0.1.1"
+VERSION = "0.1.2"
 GITHUB_REPO = "VedankPurohit/LiveRecall"
 RELEASES_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
 

--- a/liverecall.spec
+++ b/liverecall.spec
@@ -12,7 +12,7 @@ IS_WINDOWS = sys.platform == 'win32'
 
 # App metadata
 APP_NAME = 'LiveRecall'
-APP_VERSION = '0.1.0'
+APP_VERSION = '0.1.2'
 APP_BUNDLE_ID = 'com.liverecall.app'
 
 # Paths

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -27,7 +27,7 @@ from pathlib import Path
 # ============================================================================
 # Configuration
 # ============================================================================
-VERSION = "0.1.1"
+VERSION = "0.1.2"
 APP_NAME = "LiveRecall"
 ROOT = Path(__file__).parent.parent.resolve()
 

--- a/tray/__init__.py
+++ b/tray/__init__.py
@@ -3,4 +3,4 @@ LiveRecall System Tray Application
 Cross-platform menu bar / system tray for managing LiveRecall
 """
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liverecall-web",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Update version to 0.1.2 across all files

## Files updated
- api/main.py
- core/updater.py
- liverecall.spec
- scripts/build_release.py
- tray/__init__.py
- web/package.json
