### PR TITLE
Add version-change detection and setup flow

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -13,7 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
-from api.routes import compression, recording, screenshots, search, status, sync
+from api.routes import compression, recording, screenshots, search, setup, status, sync
 from core.database import db
 
 
@@ -120,6 +120,7 @@ app.include_router(sync.router, prefix="/api/v1")
 app.include_router(search.router, prefix="/api/v1")
 app.include_router(screenshots.router, prefix="/api/v1")
 app.include_router(compression.router, prefix="/api/v1")
+app.include_router(setup.router, prefix="/api/v1")
 
 
 # Serve static web UI if available

--- a/api/routes/setup.py
+++ b/api/routes/setup.py
@@ -1,0 +1,93 @@
+"""
+Setup API Routes
+Handle first-run and version-change setup flow for screen recording permissions
+"""
+
+import subprocess
+import sys
+
+from fastapi import APIRouter, HTTPException
+
+from api.schemas import SetupStatus, SuccessResponse
+from core.config import config
+from core.updater import VERSION
+
+router = APIRouter(prefix="/setup", tags=["Setup"])
+
+
+@router.get("/status", response_model=SetupStatus)
+async def get_setup_status():
+    """
+    Check if setup is needed.
+
+    Returns whether the app version has changed since last run,
+    which indicates that screen recording permissions may need to be reset.
+    """
+    needs_setup = config.last_seen_version != VERSION
+    return SetupStatus(
+        current_version=VERSION,
+        last_seen_version=config.last_seen_version,
+        needs_setup=needs_setup,
+    )
+
+
+@router.post("/reset-permissions", response_model=SuccessResponse)
+async def reset_screen_capture_permissions():
+    """
+    Reset screen capture permissions for LiveRecall.
+
+    This runs: tccutil reset ScreenCapture com.liverecall.app
+
+    Note: This will prompt the user for their admin password via macOS dialog.
+    Only available on macOS.
+    """
+    if sys.platform != "darwin":
+        raise HTTPException(
+            status_code=400,
+            detail="Permission reset is only available on macOS",
+        )
+
+    try:
+        # Run tccutil to reset screen capture permissions
+        # This will prompt for admin password via macOS system dialog
+        result = subprocess.run(
+            ["tccutil", "reset", "ScreenCapture", "com.liverecall.app"],
+            capture_output=True,
+            text=True,
+            timeout=60,  # 60 second timeout for user to enter password
+        )
+
+        if result.returncode != 0:
+            return SuccessResponse(
+                success=False,
+                message=f"Permission reset failed: {result.stderr or 'Unknown error'}",
+            )
+
+        return SuccessResponse(
+            success=True,
+            message="Screen capture permissions reset. Please grant permission when prompted.",
+        )
+    except subprocess.TimeoutExpired:
+        return SuccessResponse(
+            success=False,
+            message="Permission reset timed out. Please try again.",
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/complete", response_model=SuccessResponse)
+async def complete_setup():
+    """
+    Mark setup as complete.
+
+    Updates the last_seen_version to current version so setup won't show again
+    until the next version change.
+    """
+    config.last_seen_version = VERSION
+    config.save()
+
+    return SuccessResponse(
+        success=True,
+        message=f"Setup completed. Version {VERSION} marked as seen.",
+    )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -376,6 +376,19 @@ class ConfigUpdateRequest(BaseModel):
 
 
 # =============================================================================
+# Setup
+# =============================================================================
+
+
+class SetupStatus(BaseModel):
+    """Setup status for version change detection"""
+
+    current_version: str
+    last_seen_version: str
+    needs_setup: bool
+
+
+# =============================================================================
 # Generic Responses
 # =============================================================================
 

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -378,3 +378,129 @@ class TestRecordingEndpoints:
         data = response.json()
         assert data["success"] is True
         mock_service.stop.assert_called_once()
+
+
+class TestSetupEndpoints:
+    """Test setup API endpoints for version-change detection"""
+
+    @patch("api.routes.setup.config")
+    @patch("api.routes.setup.VERSION", "0.1.2")
+    def test_get_setup_status_needs_setup(self, mock_config):
+        """Should return needs_setup=True when version differs"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from api.routes.setup import router
+
+        mock_config.last_seen_version = "0.1.1"
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.get("/setup/status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["current_version"] == "0.1.2"
+        assert data["last_seen_version"] == "0.1.1"
+        assert data["needs_setup"] is True
+
+    @patch("api.routes.setup.config")
+    @patch("api.routes.setup.VERSION", "0.1.2")
+    def test_get_setup_status_no_setup_needed(self, mock_config):
+        """Should return needs_setup=False when version matches"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from api.routes.setup import router
+
+        mock_config.last_seen_version = "0.1.2"
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.get("/setup/status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["needs_setup"] is False
+
+    @patch("api.routes.setup.config")
+    @patch("api.routes.setup.VERSION", "0.1.2")
+    def test_get_setup_status_first_run(self, mock_config):
+        """Should return needs_setup=True on first run (empty version)"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from api.routes.setup import router
+
+        mock_config.last_seen_version = ""
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.get("/setup/status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["needs_setup"] is True
+
+    @patch("api.routes.setup.subprocess")
+    @patch("api.routes.setup.sys")
+    def test_reset_permissions_macos(self, mock_sys, mock_subprocess):
+        """Should run tccutil on macOS"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from api.routes.setup import router
+
+        mock_sys.platform = "darwin"
+        mock_subprocess.run.return_value.returncode = 0
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post("/setup/reset-permissions")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        mock_subprocess.run.assert_called_once()
+
+    @patch("api.routes.setup.sys")
+    def test_reset_permissions_non_macos(self, mock_sys):
+        """Should reject on non-macOS platforms"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from api.routes.setup import router
+
+        mock_sys.platform = "linux"
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post("/setup/reset-permissions")
+        assert response.status_code == 400
+        assert "only available on macOS" in response.json()["detail"]
+
+    @patch("api.routes.setup.config")
+    @patch("api.routes.setup.VERSION", "0.1.2")
+    def test_complete_setup(self, mock_config):
+        """Should update last_seen_version and save"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from api.routes.setup import router
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post("/setup/complete")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert mock_config.last_seen_version == "0.1.2"
+        mock_config.save.assert_called_once()

--- a/core/config.py
+++ b/core/config.py
@@ -98,6 +98,7 @@ class Config:
     safe_mode_enabled: bool = True
     safe_mode_level: str = "mid"  # low, mid, high
     similarity_metric: str = "cosine"  # "cosine" or "distance"
+    last_seen_version: str = ""  # Track version for setup flow
 
     # Paths (computed)
     @property
@@ -132,6 +133,7 @@ class Config:
             "safe_mode_enabled": self.safe_mode_enabled,
             "safe_mode_level": self.safe_mode_level,
             "similarity_metric": self.similarity_metric,
+            "last_seen_version": self.last_seen_version,
         }
         with open(config_path, "w") as f:
             json.dump(data, f, indent=2)
@@ -167,6 +169,7 @@ class Config:
             self.safe_mode_enabled = data.get("safe_mode_enabled", self.safe_mode_enabled)
             self.safe_mode_level = data.get("safe_mode_level", self.safe_mode_level)
             self.similarity_metric = data.get("similarity_metric", self.similarity_metric)
+            self.last_seen_version = data.get("last_seen_version", self.last_seen_version)
 
         except (json.JSONDecodeError, KeyError) as e:
             print(f"Warning: Could not load config: {e}")

--- a/tray/api_client.py
+++ b/tray/api_client.py
@@ -128,6 +128,16 @@ class APIClient:
         except Exception:
             return False
 
+    def get_json(self, endpoint: str) -> dict | None:
+        """Get JSON from an arbitrary endpoint"""
+        try:
+            resp = self.client.get(f"{self.base_url}{endpoint}")
+            if resp.status_code == 200:
+                return resp.json()
+            return None
+        except Exception:
+            return None
+
 
 # Global client instance
 api_client = APIClient()

--- a/tray/app.py
+++ b/tray/app.py
@@ -12,7 +12,7 @@ from core.updater import VERSION, check_for_updates_async
 
 from .api_client import SystemStatus, api_client
 from .backend import backend_manager
-from .config import STATUS_POLL_INTERVAL
+from .config import STATUS_POLL_INTERVAL, WEB_UI_URL
 from .icons import get_app_icon
 from .menu import MenuBuilder
 
@@ -90,6 +90,24 @@ class TrayApp:
             self._poll_status()
             time.sleep(STATUS_POLL_INTERVAL)
 
+    def _check_and_open_setup(self):
+        """Check if setup is needed and open setup page"""
+        try:
+            # Wait a moment for backend to be ready
+            time.sleep(1)
+
+            # Check setup status via API
+            status = api_client.get_json("/setup/status")
+
+            if status and status.get("needs_setup", False):
+                last_version = status.get("last_seen_version", "none")
+                current_version = status.get("current_version", "unknown")
+                print(f"Version change detected: {last_version} -> {current_version}")
+                print("Opening setup page...")
+                webbrowser.open(f"{WEB_UI_URL}/setup")
+        except Exception as e:
+            print(f"Warning: Could not check setup status: {e}")
+
     def start(self):
         """Start the tray application"""
         # Start backend
@@ -98,6 +116,9 @@ class TrayApp:
             print("Warning: Backend failed to start, continuing anyway...")
 
         backend_manager.enable_auto_restart()
+
+        # Check if setup is needed (version change or first run)
+        self._check_and_open_setup()
 
         # Create menu builder
         self._menu_builder = MenuBuilder(

--- a/web/src/__tests__/api.test.ts
+++ b/web/src/__tests__/api.test.ts
@@ -25,6 +25,9 @@ import {
   getDensity,
   deleteScreenshot,
   getImageUrl,
+  getSetupStatus,
+  resetPermissions,
+  completeSetup,
 } from '@/lib/api';
 
 // Helper to mock fetch responses
@@ -410,6 +413,48 @@ describe('API Client', () => {
       });
 
       await expect(getHealth()).rejects.toThrow('Request failed');
+    });
+  });
+
+  describe('Setup', () => {
+    it('should fetch setup status', async () => {
+      const setupData = {
+        current_version: '0.1.2',
+        last_seen_version: '0.1.1',
+        needs_setup: true,
+      };
+      mockFetch(setupData);
+
+      const result = await getSetupStatus();
+
+      expect(result).toEqual(setupData);
+      expect(fetch).toHaveBeenCalledWith('/api/v1/setup/status', expect.any(Object));
+    });
+
+    it('should reset permissions', async () => {
+      const response = { success: true, message: 'Permissions reset' };
+      mockFetch(response);
+
+      const result = await resetPermissions();
+
+      expect(result).toEqual(response);
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/setup/reset-permissions',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('should complete setup', async () => {
+      const response = { success: true, message: 'Setup completed' };
+      mockFetch(response);
+
+      const result = await completeSetup();
+
+      expect(result).toEqual(response);
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/setup/complete',
+        expect.objectContaining({ method: 'POST' })
+      );
     });
   });
 });

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+interface SetupStatus {
+  current_version: string;
+  last_seen_version: string;
+  needs_setup: boolean;
+}
+
+type SetupStep = 'welcome' | 'resetting' | 'granting' | 'complete';
+
+export default function SetupPage() {
+  const [status, setStatus] = useState<SetupStatus | null>(null);
+  const [step, setStep] = useState<SetupStep>('welcome');
+  const [error, setError] = useState<string | null>(null);
+  const [autoResetTriggered, setAutoResetTriggered] = useState(false);
+
+  useEffect(() => {
+    fetchStatus();
+  }, []);
+
+  // Auto-trigger reset when page loads and setup is needed
+  useEffect(() => {
+    if (status?.needs_setup && !autoResetTriggered && step === 'welcome') {
+      setAutoResetTriggered(true);
+      handleResetPermissions();
+    }
+  }, [status, autoResetTriggered, step]);
+
+  const fetchStatus = async () => {
+    try {
+      const response = await fetch('/api/v1/setup/status');
+      const data = await response.json();
+      setStatus(data);
+
+      // If setup not needed, go straight to complete
+      if (!data.needs_setup) {
+        setStep('complete');
+      }
+    } catch (err) {
+      console.error('Failed to fetch setup status:', err);
+    }
+  };
+
+  const handleResetPermissions = async () => {
+    setStep('resetting');
+    setError(null);
+
+    try {
+      const response = await fetch('/api/v1/setup/reset-permissions', {
+        method: 'POST',
+      });
+      const data = await response.json();
+
+      if (data.success) {
+        setStep('granting');
+      } else {
+        setError(data.message || 'Failed to reset permissions');
+        setStep('welcome');
+      }
+    } catch (err) {
+      setError('Failed to connect to backend');
+      setStep('welcome');
+    }
+  };
+
+  const handleCompleteSetup = async () => {
+    try {
+      await fetch('/api/v1/setup/complete', { method: 'POST' });
+      setStep('complete');
+    } catch (err) {
+      console.error('Failed to complete setup:', err);
+    }
+  };
+
+  const isFirstRun = status && !status.last_seen_version;
+  const isUpdate = status && status.last_seen_version && status.last_seen_version !== status.current_version;
+
+  return (
+    <div className="min-h-screen bg-black flex flex-col items-center justify-center p-4">
+      <div className="max-w-md w-full">
+        {/* Logo/Title */}
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-medium text-[#f5f5f5] mb-2">LiveRecall</h1>
+          <p className="text-sm text-[#8a8a8a]">
+            {isFirstRun
+              ? "Welcome! Let's set up screen capture."
+              : isUpdate
+                ? `Updated to v${status?.current_version}`
+                : 'Setup'}
+          </p>
+        </div>
+
+        {/* Step Content */}
+        <div className="bg-[#0f0f0f] rounded-lg border border-[#1e1e1e] p-6">
+          {step === 'welcome' && (
+            <>
+              <h2 className="text-lg font-medium text-[#f5f5f5] mb-4">
+                Screen Capture Permission
+              </h2>
+              <p className="text-sm text-[#8a8a8a] mb-4">
+                LiveRecall needs screen capture permission to record your screen.
+                {isUpdate && ' After an update, macOS requires re-granting this permission.'}
+              </p>
+              <p className="text-sm text-[#8a8a8a] mb-6">
+                Click the button below to reset permissions. You&apos;ll be prompted for your
+                admin password, then macOS will ask you to grant screen capture access.
+              </p>
+
+              {error && (
+                <div className="mb-4 p-3 bg-[#ef4444]/10 border border-[#ef4444]/20 rounded text-sm text-[#ef4444]">
+                  {error}
+                </div>
+              )}
+
+              <button
+                onClick={handleResetPermissions}
+                className="w-full py-3 px-4 bg-[#86efac] text-black rounded font-medium hover:bg-[#86efac]/90 transition-colors"
+              >
+                Reset Permissions
+              </button>
+            </>
+          )}
+
+          {step === 'resetting' && (
+            <div className="text-center py-8">
+              <div className="w-8 h-8 border-2 border-[#86efac]/30 border-t-[#86efac] rounded-full animate-spin mx-auto mb-4" />
+              <p className="text-sm text-[#8a8a8a]">Resetting permissions...</p>
+              <p className="text-xs text-[#555] mt-2">
+                Enter your admin password when prompted
+              </p>
+            </div>
+          )}
+
+          {step === 'granting' && (
+            <>
+              <h2 className="text-lg font-medium text-[#f5f5f5] mb-4">
+                Grant Permission
+              </h2>
+              <div className="space-y-4 text-sm text-[#8a8a8a] mb-6">
+                <p>Now grant screen capture permission:</p>
+                <ol className="list-decimal list-inside space-y-2 text-[#f5f5f5]">
+                  <li>A dialog will appear asking for Screen Recording permission</li>
+                  <li>
+                    Click &quot;Open System Settings&quot; or go to System Settings → Privacy &
+                    Security → Screen Recording
+                  </li>
+                  <li>Find &quot;LiveRecall&quot; and toggle it ON</li>
+                  <li>You may need to restart LiveRecall</li>
+                </ol>
+              </div>
+
+              <div className="flex gap-3">
+                <button
+                  onClick={() => {
+                    setStep('welcome');
+                    setAutoResetTriggered(false);
+                  }}
+                  className="flex-1 py-3 px-4 border border-[#333] text-[#8a8a8a] rounded font-medium hover:bg-[#1e1e1e] transition-colors"
+                >
+                  Back
+                </button>
+                <button
+                  onClick={handleCompleteSetup}
+                  className="flex-1 py-3 px-4 bg-[#86efac] text-black rounded font-medium hover:bg-[#86efac]/90 transition-colors"
+                >
+                  Done
+                </button>
+              </div>
+            </>
+          )}
+
+          {step === 'complete' && (
+            <div className="text-center py-4">
+              <div className="w-12 h-12 rounded-full bg-[#86efac]/10 flex items-center justify-center mx-auto mb-4">
+                <svg
+                  className="w-6 h-6 text-[#86efac]"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+              </div>
+              <h2 className="text-lg font-medium text-[#f5f5f5] mb-2">Setup Complete!</h2>
+              <p className="text-sm text-[#8a8a8a] mb-6">LiveRecall is ready to use.</p>
+              <Link
+                href="/"
+                className="inline-block py-3 px-8 bg-[#86efac] text-black rounded font-medium hover:bg-[#86efac]/90 transition-colors"
+              >
+                Open LiveRecall
+              </Link>
+            </div>
+          )}
+        </div>
+
+        {/* Skip option */}
+        {(step === 'welcome' || step === 'granting') && (
+          <div className="text-center mt-4">
+            <button
+              onClick={handleCompleteSetup}
+              className="text-xs text-[#555] hover:text-[#8a8a8a] transition-colors"
+            >
+              Skip setup
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -188,3 +188,20 @@ export function getImageUrl(imagePath: string): string {
   // The API serves images via /api/v1/screenshots/image endpoint
   return `${API_BASE}/screenshots/image?path=${encodeURIComponent(imagePath)}`;
 }
+
+// Setup
+export async function getSetupStatus(): Promise<{
+  current_version: string;
+  last_seen_version: string;
+  needs_setup: boolean;
+}> {
+  return fetchApi('/setup/status');
+}
+
+export async function resetPermissions(): Promise<{ success: boolean; message: string }> {
+  return fetchApi('/setup/reset-permissions', { method: 'POST' });
+}
+
+export async function completeSetup(): Promise<{ success: boolean; message: string }> {
+  return fetchApi('/setup/complete', { method: 'POST' });
+}


### PR DESCRIPTION
## Summary

- Detects version changes on startup via `last_seen_version` config field
- Opens `/setup` page automatically when version change is detected
- Runs `tccutil reset ScreenCapture` to reset TCC permissions (macOS)
- Guides user through granting screen recording permission in System Settings

## Changes

**Backend:**
- `core/config.py`: Added `last_seen_version` field to track seen versions
- `api/routes/setup.py`: New router with 3 endpoints (`/status`, `/reset-permissions`, `/complete`)
- `api/schemas.py`: Added `SetupStatus` schema
- `api/main.py`: Registered setup router

**Tray:**
- `tray/app.py`: Added `_check_and_open_setup()` called on startup
- `tray/api_client.py`: Added `get_json()` method for arbitrary endpoints

**Frontend:**
- `web/src/app/setup/page.tsx`: 4-step setup wizard UI
- `web/src/lib/api.ts`: Added setup API functions

**Tests:**
- Added 6 Python tests for setup endpoints
- Added 3 TypeScript tests for setup API functions

## Test plan

- [ ] Build app and run fresh install
- [ ] Verify setup page opens on first run
- [ ] Test permission reset flow on macOS
- [ ] Simulate version change and verify setup triggers